### PR TITLE
Implement expirations for auth codes and access tokens

### DIFF
--- a/id/src/db/oidc_access_tokens.ts
+++ b/id/src/db/oidc_access_tokens.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, gt } from "drizzle-orm";
 import db, { schema } from ".";
 
 export async function createOidcAccessToken(
@@ -15,7 +15,10 @@ export async function findOidcAccessToken(id: string) {
   }
 
   return db.query.oidcAccessTokens.findFirst({
-    where: eq(schema.oidcAccessTokens.id, id),
+    where: and(
+      eq(schema.oidcAccessTokens.id, id),
+      gt(schema.oidcAccessTokens.expiresAt, new Date()),
+    ),
   });
 }
 

--- a/id/src/db/oidc_access_tokens.ts
+++ b/id/src/db/oidc_access_tokens.ts
@@ -10,6 +10,10 @@ export async function createOidcAccessToken(
 }
 
 export async function findOidcAccessToken(id: string) {
+  if (!id.match(/^[0-9a-f-]{36}$/)) {
+    return null;
+  }
+
   return db.query.oidcAccessTokens.findFirst({
     where: eq(schema.oidcAccessTokens.id, id),
   });

--- a/id/src/lib/oidc/token.spec.ts
+++ b/id/src/lib/oidc/token.spec.ts
@@ -195,6 +195,22 @@ describe("Token endpoint", () => {
       expect(await response2.json()).toEqual({ error: "invalid_grant" });
     });
 
+    test("the code expires in a short time", async () => {
+      const code = await makeCode({
+        // 5 minutes ago
+        createdAt: new Date(Date.now() - 5 * 60 * 1000),
+      });
+      const response = await tokenEndpoint(
+        makeRequest({
+          body: { grant_type: "authorization_code", code: code.id },
+          headers: { Authorization: basicHeader },
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "invalid_grant" });
+    });
+
     test("it returns a valid id_token", async () => {
       const code = await makeCode();
       const response = await tokenEndpoint(

--- a/id/src/lib/oidc/userinfo.spec.ts
+++ b/id/src/lib/oidc/userinfo.spec.ts
@@ -1,0 +1,178 @@
+import OidcAccessTokens from "@/db/oidc_access_tokens";
+import { describe, expect, test } from "bun:test";
+import { HttpRequest } from "../http/request";
+import { userinfoEndpoint } from "./userinfo";
+
+describe("Userinfo endpoint", () => {
+  const makeRequest = ({
+    body,
+    headers,
+  }: {
+    body?: string | Record<string, string>;
+    headers?: Record<string, string>;
+  } = {}) =>
+    new HttpRequest(
+      new Request("https://localhost:23000/oidc/userinfo", {
+        method: "POST",
+        headers: {
+          "X-Forwarded-Proto": "https",
+          Host: "localhost:23000",
+          Origin: "https://example.com",
+          ...headers,
+        },
+        body:
+          typeof body === "string"
+            ? body
+            : new URLSearchParams(body).toString(),
+      }),
+    );
+
+  const makeAccessToken = async (attributes = {}) =>
+    await OidcAccessTokens.create({
+      clientId: "00000000-0000-0000-0000-000000000001",
+      userId: "00000000-0000-0000-0000-000000000001",
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+      ...attributes,
+    });
+
+  test("requires an access token as a Bearer token", async () => {
+    const response = await userinfoEndpoint(makeRequest());
+    expect(response.status).toBe(401);
+  });
+
+  test("the access token must be valid", async () => {
+    const response = await userinfoEndpoint(
+      makeRequest({
+        headers: { Authorization: "Bearer invalid" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("it works when the AT is valid", async () => {
+    const at = await makeAccessToken();
+
+    const response = await userinfoEndpoint(
+      makeRequest({
+        headers: { Authorization: "Bearer " + at.id },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  test("it works when the AT is passed as a form parameter", async () => {
+    const at = await makeAccessToken();
+
+    const response = await userinfoEndpoint(
+      makeRequest({
+        body: { access_token: at.id },
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  test("respects access token expiration", async () => {
+    const at = await makeAccessToken({
+      // 5 minutes ago
+      expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+    });
+
+    const response = await userinfoEndpoint(
+      makeRequest({
+        headers: { Authorization: "Bearer " + at.id },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("it returns claims about the user", async () => {
+    const at = await makeAccessToken();
+    const response = await userinfoEndpoint(
+      makeRequest({
+        headers: { Authorization: "Bearer " + at.id },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      iss: "https://localhost:23000/oidc",
+      sub: expect.stringContaining("usr_"),
+      aud: "00000000-0000-0000-0000-000000000001",
+      exp: expect.any(Number),
+      iat: expect.any(Number),
+      nonce: at.nonce,
+    });
+  });
+
+  test("returns the claims requested in the id_token", async () => {
+    const at = await makeAccessToken({
+      claims: JSON.stringify({
+        id_token: {
+          given_name: null,
+        },
+        userinfo: {
+          family_name: null,
+        },
+      }),
+    });
+
+    const response = await userinfoEndpoint(
+      makeRequest({
+        headers: { Authorization: "Bearer " + at.id },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      family_name: "Doe",
+    });
+
+    expect(Object.keys(body)).not.toContain("given_name");
+  });
+
+  test("sets CORS headers", async () => {
+    const request = new Request("https://localhost:23000/oidc/userinfo", {
+      method: "OPTIONS",
+      headers: {
+        "Access-Control-Request-Method": "POST",
+        Origin: "https://example.com",
+      },
+    });
+
+    const response = await userinfoEndpoint(new HttpRequest(request));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://example.com",
+    );
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe(
+      "GET, POST, OPTIONS",
+    );
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe(
+      "Authorization, Content-Type",
+    );
+    expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
+  test("sets cache headers", async () => {
+    const request = new Request("https://localhost:23000/oidc/userinfo", {
+      method: "GET",
+      headers: {
+        Origin: "https://example.com",
+      },
+    });
+
+    const response = await userinfoEndpoint(new HttpRequest(request));
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+});

--- a/id/src/lib/oidc/userinfo.ts
+++ b/id/src/lib/oidc/userinfo.ts
@@ -41,12 +41,17 @@ async function handle(req: HttpRequest) {
     return new Response(null, { status: 401 });
   }
 
+  if (at.expiresAt < new Date()) {
+    OidcAccessTokens.delete(at.id);
+    return new Response(null, { status: 401 });
+  }
+
   const client = await OidcClients.find(at.clientId);
   if (!client) {
     return new Response(null, { status: 401 });
   }
 
-  let issuer = req.baseUrl;
+  let issuer = `${req.baseUrl}/oidc`;
   const tenant = client.tenantId
     ? await Tenants.find(client.tenantId)
     : undefined;
@@ -63,7 +68,7 @@ async function handle(req: HttpRequest) {
     exp: Math.floor(new Date().getTime() / 1000) + 3600,
     iat: Math.floor(new Date().getTime() / 1000),
     nonce: at.nonce,
-    ...requestedUserClaims(at.claims, user),
+    ...requestedUserClaims(at.claims.userinfo, user),
   };
 
   // TODO: check client.userinfoSignedResponseAlg. If set, JWT encode the claims

--- a/id/src/lib/oidc/userinfo.ts
+++ b/id/src/lib/oidc/userinfo.ts
@@ -41,11 +41,6 @@ async function handle(req: HttpRequest) {
     return new Response(null, { status: 401 });
   }
 
-  if (at.expiresAt < new Date()) {
-    OidcAccessTokens.delete(at.id);
-    return new Response(null, { status: 401 });
-  }
-
   const client = await OidcClients.find(at.clientId);
   if (!client) {
     return new Response(null, { status: 401 });


### PR DESCRIPTION
Auth codes have a lifetime of 1 minute, as required by the FAPI 2.0 security profile (and I don't see a reason to make it any larger than that for other profiles).

Access tokens for now will last 1 hour.