### PR TITLE
OIDC vs OAuth 2.0

### DIFF
--- a/id/package.json
+++ b/id/package.json
@@ -2,6 +2,7 @@
   "name": "id",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "PORT=${PORT:-13000} next dev --turbopack --experimental-https",
     "dev:http": "PORT=${PORT:-13000} next dev --turbopack",
@@ -13,7 +14,7 @@
     "test:e2e:ui": "playwright test --ui",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "db:test:push": "TEST=1 drizzle-kit push",
+    "db:test:push": "TEST=1 bun run --bun drizzle-kit push",
     "db:test:fixtures": "TEST=1 bun run ./tests/fixtures.ts",
     "keys:rotate": "bun run ./scripts/rotateKeys.ts"
   },

--- a/id/playwright.config.ts
+++ b/id/playwright.config.ts
@@ -4,9 +4,6 @@ import { defineConfig, devices } from "@playwright/test";
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/id/scripts/translate.ts
+++ b/id/scripts/translate.ts
@@ -76,12 +76,7 @@ function recursiveKeyCheck(
       if (typeof other[key] === "string" || !other[key]) {
         other[key] = {};
       }
-      recursiveKeyCheck(
-        reference[key] as TranslationFile,
-        other[key] as TranslationFile,
-        misses,
-        `${prefix}${key}.`,
-      );
+      recursiveKeyCheck(reference[key], other[key], misses, `${prefix}${key}.`);
     } else {
       if (typeof other[key] === "object") {
         delete other[key];

--- a/id/src/app/oidc/[domain]/end_session/route.ts
+++ b/id/src/app/oidc/[domain]/end_session/route.ts
@@ -98,10 +98,10 @@ async function prepareEndSession(request: HttpRequest, domain: string) {
   const params: Record<string, string> = {};
 
   if (!client && decoded) {
-    const humanClientId = Array.isArray(decoded.aud)
-      ? decoded.aud[0]
-      : decoded.aud;
-    const clientId = humanIdToUuid(humanClientId!, "oidc")!;
+    const humanClientId = (
+      Array.isArray(decoded.aud) ? decoded.aud[0] : decoded.aud
+    ) as string;
+    const clientId = humanIdToUuid(humanClientId, "oidc")!;
     client = await OidcClients.findWithTenant(clientId, tenant.id);
     if (!client || alg !== client.idTokenSignedResponseAlg) {
       return failure(request);

--- a/id/src/app/oidc/[domain]/end_session_confirm/page.tsx
+++ b/id/src/app/oidc/[domain]/end_session_confirm/page.tsx
@@ -74,7 +74,7 @@ export default async function EndSession({
       return finish(client, query.postLogoutRedirectUri, query.state);
     }
 
-    const svc = await new SessionsService(await getSessionCookie());
+    const svc = new SessionsService(await getSessionCookie());
     const sessions = await svc.activeSessions();
 
     let matchingSession: Session | undefined;

--- a/id/src/app/oidc/configuration.ts
+++ b/id/src/app/oidc/configuration.ts
@@ -89,7 +89,7 @@ export const SUBJECT_TYPES_SUPPORTED = ["public", "pairwise"];
 
 export function buildConfiguration(request: Request, domain?: string) {
   const host = request.headers.get("host");
-  const proto = request.headers.get("x-forwarded-proto") || "https";
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
   const issuer = `${proto}://${host}/oidc` + (domain ? `/${domain}` : "");
 
   const config: ProviderMetadata = {

--- a/id/src/app/oidc/configuration.ts
+++ b/id/src/app/oidc/configuration.ts
@@ -85,6 +85,8 @@ export const CLAIMS_SUPPORTED = [
   "family_name",
 ];
 
+export const SUBJECT_TYPES_SUPPORTED = ["public", "pairwise"];
+
 export function buildConfiguration(request: Request, domain?: string) {
   const host = request.headers.get("host");
   const proto = request.headers.get("x-forwarded-proto") || "https";
@@ -98,7 +100,7 @@ export function buildConfiguration(request: Request, domain?: string) {
     jwks_uri: `${proto}://${host}/oidc/jwks.json`,
     scopes_supported: ["openid", "profile", "email", "address", "phone"],
     response_types_supported: [...RESPONSE_TYPES_SUPPORTED],
-    subject_types_supported: ["public", "pairwise"],
+    subject_types_supported: SUBJECT_TYPES_SUPPORTED,
     grant_types_supported: GRANT_TYPES_SUPPORTED,
     id_token_signing_alg_values_supported:
       ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED,

--- a/id/src/app/oidc/configuration.ts
+++ b/id/src/app/oidc/configuration.ts
@@ -44,6 +44,9 @@ export const RESPONSE_TYPES_SUPPORTED = [
   "code",
   "id_token",
   "id_token token",
+  "code id_token",
+  "code token",
+  "code id_token token",
 ] as const;
 
 export const GRANT_TYPES_SUPPORTED = [

--- a/id/src/app/oidc/fatal/page.tsx
+++ b/id/src/app/oidc/fatal/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PageModal } from "@/components/PageModal";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "use-intl";
 
@@ -8,12 +9,14 @@ export default function OidcFatalErrorPage() {
   const t = useTranslations("oidc.fatal");
 
   return (
-    <>
-      <h1 className="text-xl font-medium mb-4">{t("title")}</h1>
-      <p>{t("description")}</p>
-      <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded-md my-4">
-        {t("error", { error: query.get("error") })}
-      </pre>
-    </>
+    <PageModal className="!max-w-lg">
+      <PageModal.Modal className="max-w-lg mx-auto !block">
+        <h1 className="text-xl font-medium mb-4">{t("title")}</h1>
+        <p>{t("description")}</p>
+        <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded-md my-4">
+          {t("error", { error: query.get("error") })}
+        </pre>
+      </PageModal.Modal>
+    </PageModal>
   );
 }

--- a/id/src/app/oidc/jwks.ts
+++ b/id/src/app/oidc/jwks.ts
@@ -203,8 +203,12 @@ function loadKeyRaw(path: string): Promise<Record<string, unknown>> {
       try {
         const key = keySchema.parse(JSON.parse(data.toString()));
         resolve(key);
-      } catch (err) {
-        reject(err);
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          reject(err);
+        } else {
+          reject(new Error(`Failed to parse key: ${err}`));
+        }
       }
     });
   });

--- a/id/src/app/page.tsx
+++ b/id/src/app/page.tsx
@@ -1,13 +1,8 @@
-import { SESSION_COOKIE_NAME, SessionsService } from "@/lib/SessionsService";
-import { cookies } from "next/headers";
+import { getSessionCookie, SessionsService } from "@/lib/SessionsService";
 import { redirect } from "next/navigation";
 
 export async function getCurrentUser() {
-  const cookieStore = await cookies();
-  const sessionManager = new SessionsService(
-    cookieStore.get(SESSION_COOKIE_NAME)?.value ?? "",
-  );
-
+  const sessionManager = new SessionsService(await getSessionCookie());
   return sessionManager.getUser();
 }
 

--- a/id/src/app/page.tsx
+++ b/id/src/app/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 export async function getCurrentUser() {
   const cookieStore = await cookies();
   const sessionManager = new SessionsService(
-    cookieStore.get(SESSION_COOKIE_NAME)?.value || "",
+    cookieStore.get(SESSION_COOKIE_NAME)?.value ?? "",
   );
 
   return sessionManager.getUser();

--- a/id/src/app/signin/actions.ts
+++ b/id/src/app/signin/actions.ts
@@ -5,11 +5,10 @@ import Users from "@/db/users";
 import { getIpAddress, getUserAgent } from "@/lib/http/nextUtils";
 import { getOidcAuthorizationRequest } from "@/lib/oidc/utils";
 import {
-  SESSION_COOKIE_NAME,
+  getSessionCookie,
   SessionsService,
   setSessionCookie,
 } from "@/lib/SessionsService";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 
@@ -47,9 +46,7 @@ export async function signin(_: unknown, formData: FormData) {
     throw new Error("OTP step not implemented");
   }
 
-  const cookieStore = await cookies();
-  const cookie = cookieStore.get(SESSION_COOKIE_NAME)?.value || "";
-  const svc = new SessionsService(cookie);
+  const svc = new SessionsService(await getSessionCookie());
 
   let session = await svc.sessionFor(user);
   if (session) {

--- a/id/src/app/signup/actions.ts
+++ b/id/src/app/signup/actions.ts
@@ -3,7 +3,11 @@
 import { schema } from "@/db";
 import { getIpAddress, getUserAgent } from "@/lib/http/nextUtils";
 import { getOidcAuthorizationRequest } from "@/lib/oidc/utils";
-import { SESSION_COOKIE_NAME, SessionsService } from "@/lib/SessionsService";
+import {
+  getSessionCookie,
+  SESSION_COOKIE_NAME,
+  SessionsService,
+} from "@/lib/SessionsService";
 import { SignupService } from "@/lib/SignupService";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
@@ -103,9 +107,7 @@ export async function signupStep3(prevState: unknown, formData: FormData) {
 
 async function startSession(user: typeof schema.users.$inferSelect) {
   const cookieStore = await cookies();
-  const sessionManager = new SessionsService(
-    cookieStore.get(SESSION_COOKIE_NAME)?.value || "",
-  );
+  const sessionManager = new SessionsService(await getSessionCookie());
 
   const session = await sessionManager.startSession(
     user.id,

--- a/id/src/components/ClientDescription.tsx
+++ b/id/src/components/ClientDescription.tsx
@@ -12,7 +12,7 @@ export function ClientDescription({ name, descriptionKey }: Props) {
 
   return (
     <>
-      {t.rich(descriptionKey || "switch.description", {
+      {t.rich(descriptionKey ?? "switch.description", {
         name,
         details: (children) => (
           // TODO: Show contacts and host of redirect_uri on click

--- a/id/src/db/index.ts
+++ b/id/src/db/index.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { existsSync } from "fs";
 import * as schema from "./schema";
@@ -38,4 +39,8 @@ if (!process.env.DATABASE_URL) {
 const databaseUrl = process.env.DATABASE_URL!;
 
 export { databaseUrl, schema };
-export default drizzle(databaseUrl, { schema });
+
+const client = drizzle(databaseUrl, { schema });
+await client.execute(sql`SET TIME ZONE 'UTC';`);
+
+export default client;

--- a/id/src/db/index.ts
+++ b/id/src/db/index.ts
@@ -36,11 +36,13 @@ if (!process.env.DATABASE_URL) {
   }
 }
 
-const databaseUrl = process.env.DATABASE_URL!;
+const databaseUrl = process.env.DATABASE_URL;
 
 export { databaseUrl, schema };
 
 const client = drizzle(databaseUrl, { schema });
-await client.execute(sql`SET TIME ZONE 'UTC';`);
+/* await (causes all sorts of ESM problems */ client.execute(
+  sql`SET TIME ZONE 'UTC';`,
+);
 
 export default client;

--- a/id/src/db/oidc_access_tokens.ts
+++ b/id/src/db/oidc_access_tokens.ts
@@ -10,7 +10,7 @@ export async function createOidcAccessToken(
 }
 
 export async function findOidcAccessToken(id: string) {
-  if (!id.match(/^[0-9a-f-]{36}$/)) {
+  if (!/^[0-9a-f-]{36}$/.exec(id)) {
     return null;
   }
 

--- a/id/src/db/sessions.ts
+++ b/id/src/db/sessions.ts
@@ -39,7 +39,7 @@ export function refreshSession(
     ip,
     userAgent,
     lastUsedAt: new Date(),
-    lastAuthenticatedAt: authenticatedAt ? authenticatedAt : undefined,
+    lastAuthenticatedAt: authenticatedAt,
   };
 
   return db

--- a/id/src/db/sessions.ts
+++ b/id/src/db/sessions.ts
@@ -4,6 +4,7 @@ import db, { schema } from ".";
 export function find(sessionId: string) {
   return db.query.sessions.findFirst({
     where: eq(schema.sessions.id, sessionId),
+    with: { user: { with: { tenant: true } } },
   });
 }
 
@@ -60,4 +61,4 @@ const Sessions = {
 };
 
 export default Sessions;
-export type Session = typeof schema.sessions.$inferSelect;
+export type Session = NonNullable<Awaited<ReturnType<typeof Sessions.find>>>;

--- a/id/src/i18n/request.ts
+++ b/id/src/i18n/request.ts
@@ -23,7 +23,7 @@ export default getRequestConfig(async () => {
     const reqHeaders = await headers();
     const lngHeader = reqHeaders.get("accept-language");
 
-    locale = acceptLanguage.get(lngHeader) || "en";
+    locale = acceptLanguage.get(lngHeader) ?? "en";
   }
 
   return {

--- a/id/src/lib/SessionsService.ts
+++ b/id/src/lib/SessionsService.ts
@@ -23,7 +23,7 @@ export const SESSION_CHECK_COOKIE_NAME = "_noo_auth_check";
 
 export async function getSessionCookie() {
   const cookieStore = await cookies();
-  return cookieStore.get(SESSION_COOKIE_NAME)?.value || "";
+  return cookieStore.get(SESSION_COOKIE_NAME)?.value ?? "";
 }
 
 export async function setSessionCookie(value: string) {
@@ -74,7 +74,7 @@ export class SessionsService {
 
     const { verifier, digest } = createVerifier();
 
-    const session = await Sessions.create({
+    await Sessions.create({
       id: sid,
       userId: userId,
       verifierDigest: digest,
@@ -89,7 +89,8 @@ export class SessionsService {
 
     this.tokens.push(this.encodeSession(sid, verifier));
 
-    return session;
+    // This returns the user along with the session
+    return (await Sessions.find(sid))!;
   }
 
   async endSession(sid: string) {

--- a/id/src/lib/SessionsService.ts
+++ b/id/src/lib/SessionsService.ts
@@ -1,5 +1,5 @@
 import Sessions, { refreshSession, Session } from "@/db/sessions";
-import Users, { User } from "@/db/users";
+import { User } from "@/db/users";
 import { checkVerifier, createVerifier, sha256 } from "@/utils";
 import { inArray } from "drizzle-orm";
 import { cookies } from "next/headers";
@@ -134,7 +134,7 @@ export class SessionsService {
       return undefined;
     }
 
-    return Users.find(session.userId);
+    return session.user;
   }
 
   async getSessionBySid(sessionId: string) {
@@ -162,7 +162,7 @@ export class SessionsService {
       return undefined;
     }
 
-    return Users.find(session.userId);
+    return session.user;
   }
 
   async cleanup() {

--- a/id/src/lib/http/nextUtils.ts
+++ b/id/src/lib/http/nextUtils.ts
@@ -3,13 +3,13 @@ import { headers } from "next/headers";
 export async function getIpAddress() {
   const headerStore = await headers();
   const ipHeader =
-    headerStore.get("x-real-ip") ||
-    headerStore.get("x-forwarded-for") ||
+    headerStore.get("x-real-ip") ??
+    headerStore.get("x-forwarded-for") ??
     "0.0.0.0";
   return ipHeader.split(",")[0];
 }
 
 export async function getUserAgent() {
   const headerStore = await headers();
-  return headerStore.get("user-agent") || "";
+  return headerStore.get("user-agent") ?? "";
 }

--- a/id/src/lib/http/request.ts
+++ b/id/src/lib/http/request.ts
@@ -80,8 +80,8 @@ export class HttpRequest {
 
   get remoteAddr(): string {
     const ipHeader =
-      this.request.headers.get("X-Forwarded-For") ||
-      this.request.headers.get("X-Real-Ip") ||
+      this.request.headers.get("X-Forwarded-For") ??
+      this.request.headers.get("X-Real-Ip") ??
       "127.0.0.1";
     return ipHeader.split(",")[0];
   }

--- a/id/src/lib/oidc/authorization/response.ts
+++ b/id/src/lib/oidc/authorization/response.ts
@@ -1,0 +1,95 @@
+import { RESPONSE_TYPES_SUPPORTED } from "@/app/oidc/configuration";
+import OidcAccessTokens from "@/db/oidc_access_tokens";
+import OidcClients from "@/db/oidc_clients";
+import { Session } from "@/db/sessions";
+import { SESSION_CHECK_COOKIE_NAME } from "@/lib/SessionsService";
+import { sha256, uuidToHumanId } from "@/utils";
+import { cookies } from "next/headers";
+import { AuthorizationRequest, createCode } from "../authorization";
+import { createIdToken, idTokenHash } from "../idToken";
+import { requestedUserClaims } from "../userClaims";
+
+export async function buildAuthorizationResponse(
+  params: AuthorizationRequest,
+  session: Session,
+) {
+  if (!RESPONSE_TYPES_SUPPORTED.includes(params.response_type)) {
+    throw new Error("Unsupported response type");
+  }
+
+  const parts = params.response_type.split(" ");
+
+  const response: Record<string, string> = {};
+  const client = (await OidcClients.find(params.client_id))!;
+  const user = session.user;
+
+  if (parts.includes("code")) {
+    const code = await createCode(session, params);
+    response.code = code.id;
+  }
+
+  if (parts.includes("token")) {
+    const accessToken = await OidcAccessTokens.create({
+      clientId: client.id,
+      userId: user.id,
+      scopes: params.scopes,
+      claims: params.claims,
+      nonce: params.nonce,
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+    });
+
+    response.access_token = uuidToHumanId(accessToken.id, "oidc_at");
+    response.token_type = "Bearer";
+    response.expires_in = "3600";
+  }
+
+  if (parts.includes("id_token")) {
+    const c_hash = response.code
+      ? idTokenHash(client, response.code)
+      : undefined;
+    const at_hash = response.access_token
+      ? idTokenHash(client, response.access_token)
+      : undefined;
+
+    response.id_token = await createIdToken(
+      params.issuer,
+      client,
+      user.id,
+      session.lastAuthenticatedAt,
+      {
+        ...requestedUserClaims(params.claims.id_token, user),
+        nonce: params.nonce,
+        at_hash,
+        c_hash,
+      },
+    );
+  }
+
+  response.session_state = await buildSessionState(
+    client.id,
+    params.redirect_uri,
+  );
+
+  return response;
+}
+
+export async function buildSessionState(clientId: string, redirectUri: string) {
+  const cookieStore = await cookies();
+  const checkCookie = cookieStore.get(SESSION_CHECK_COOKIE_NAME)?.value;
+  if (!checkCookie) {
+    throw new Error("No check session cookie found");
+  }
+
+  const salt = Buffer.from(crypto.getRandomValues(new Uint8Array(16))).toString(
+    "base64url",
+  );
+
+  const humanClientId = clientId.startsWith("oidc_")
+    ? clientId
+    : uuidToHumanId(clientId, "oidc");
+
+  const origin = new URL(redirectUri).origin;
+  const state = humanClientId + " " + origin + " " + checkCookie + " " + salt;
+
+  return `${sha256(state).digest("base64url")}.${salt}`;
+}

--- a/id/src/lib/oidc/registration.ts
+++ b/id/src/lib/oidc/registration.ts
@@ -174,7 +174,7 @@ async function validateRegistration(
 
   // Validate grant types, tolerate missing grant_types
   config.grant_types ??= ["authorization_code"];
-  const all_response_types = config.response_types.join(" ") || "";
+  const all_response_types = config.response_types.join(" ");
   config.grant_types = config.grant_types.filter((gt: string) =>
     GRANT_TYPES_SUPPORTED.includes(gt),
   );

--- a/id/src/lib/oidc/registration.ts
+++ b/id/src/lib/oidc/registration.ts
@@ -3,6 +3,7 @@ import {
   GRANT_TYPES_SUPPORTED,
   ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED,
   RESPONSE_TYPES_SUPPORTED,
+  SUBJECT_TYPES_SUPPORTED,
   TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED,
 } from "@/app/oidc/configuration";
 import { jwks } from "@/app/oidc/jwks";
@@ -83,9 +84,9 @@ export async function oidcClientRegistration(
   }
 
   const config = parseResult.data;
-  config.application_type ||= "web";
-  config.subject_type ||= "pairwise";
-  config.require_auth_time ||= false;
+  config.application_type ??= "web";
+  config.subject_type ??= "pairwise";
+  config.require_auth_time ??= false;
 
   const clientName = extractLocalizedField(params, "client_name");
   const logoUri = extractLocalizedField(params, "logo_uri");
@@ -160,7 +161,7 @@ async function validateRegistration(
   }
 
   // Ensure only supported response types are set
-  config.response_types ||= ["code"];
+  config.response_types ??= ["code"];
   config.response_types = config.response_types?.filter((rt: string) =>
     RESPONSE_TYPES_SUPPORTED.includes(rt as ResponseType),
   );
@@ -172,19 +173,19 @@ async function validateRegistration(
   }
 
   // Validate grant types, tolerate missing grant_types
-  config.grant_types ||= ["authorization_code"];
+  config.grant_types ??= ["authorization_code"];
   const all_response_types = config.response_types.join(" ") || "";
   config.grant_types = config.grant_types.filter((gt: string) =>
     GRANT_TYPES_SUPPORTED.includes(gt),
   );
   if (!config.grant_types.includes("authorization_code")) {
-    if (all_response_types.match(/\bcode\b/)) {
+    if (/\bcode\b/.exec(all_response_types)) {
       config.grant_types.push("authorization_code");
     }
   }
 
   if (!config.grant_types.includes("implicit")) {
-    if (all_response_types.match(/token\b/)) {
+    if (/token\b/.exec(all_response_types)) {
       config.grant_types.push("implicit");
     }
   }
@@ -225,60 +226,17 @@ async function validateRegistration(
     }
   }
 
-  if (config.sector_identifier_uri && config.subject_type === "pairwise") {
-    const sectorIdentifierUri = new URL(config.sector_identifier_uri);
-    if (sectorIdentifierUri.protocol !== "https:") {
-      return buildErrorResponse(
-        "invalid_client_metadata",
-        "Sector Identifier URI must use HTTPS.",
-      );
-    }
-
-    let sectorIdentifierData;
-    try {
-      const sectorIdentifierResponse = await fetch(
-        config.sector_identifier_uri,
-        {
-          headers: {
-            Accept: "application/json",
-          },
-          signal: AbortSignal.timeout(2000),
-        },
-      );
-
-      if (!sectorIdentifierResponse.ok) {
-        return buildErrorResponse(
-          "invalid_client_metadata",
-          "Failed to fetch sector identifier URI.",
-        );
-      }
-
-      sectorIdentifierData = await sectorIdentifierResponse.json();
-      if (!Array.isArray(sectorIdentifierData)) {
-        return buildErrorResponse(
-          "invalid_client_metadata",
-          "Sector Identifier URI must return an array.",
-        );
-      }
-    } catch {
-      return buildErrorResponse(
-        "invalid_client_metadata",
-        "Failed to fetch sector identifier URI.",
-      );
-    }
-
-    for (const uri of config.redirect_uris) {
-      if (!sectorIdentifierData.includes(uri)) {
-        return buildErrorResponse(
-          "invalid_client_metadata",
-          "All Redirect URIs must be included in sector identifier.",
-        );
-      }
-    }
+  if (!SUBJECT_TYPES_SUPPORTED.includes(config.subject_type as string)) {
+    config.subject_type = "pairwise";
   }
 
-  if (config.subject_type !== "pairwise" && config.subject_type !== "public") {
-    config.subject_type = "pairwise";
+  if (config.sector_identifier_uri && config.subject_type === "pairwise") {
+    const sectorIdentifierValidationResult =
+      await validateSectorIdentifier(config);
+
+    if (sectorIdentifierValidationResult) {
+      return sectorIdentifierValidationResult;
+    }
   }
 
   if (config.id_token_signed_response_alg === "none") {
@@ -294,7 +252,7 @@ async function validateRegistration(
     }
   }
 
-  config.id_token_signed_response_alg ||= "RS256";
+  config.id_token_signed_response_alg ??= "RS256";
   if (
     !ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED.includes(
       config.id_token_signed_response_alg,
@@ -308,11 +266,15 @@ async function validateRegistration(
 
   if (
     config.id_token_encrypted_response_alg ||
-    config.id_token_encrypted_response_enc
+    config.id_token_encrypted_response_enc ||
+    config.userinfo_encrypted_response_alg ||
+    config.userinfo_encrypted_response_enc ||
+    config.request_object_encryption_alg ||
+    config.request_object_encryption_enc
   ) {
     return buildErrorResponse(
       "invalid_client_metadata",
-      "ID Token encryption is not supported.",
+      "JWE is not supported.",
     );
   }
 
@@ -329,16 +291,6 @@ async function validateRegistration(
   }
 
   if (
-    config.userinfo_encrypted_response_alg ||
-    config.userinfo_encrypted_response_enc
-  ) {
-    return buildErrorResponse(
-      "invalid_client_metadata",
-      "Userinfo encryption is not supported.",
-    );
-  }
-
-  if (
     config.request_object_signing_alg &&
     !ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED.includes(
       config.request_object_signing_alg,
@@ -350,17 +302,7 @@ async function validateRegistration(
     );
   }
 
-  if (
-    config.request_object_encryption_alg ||
-    config.request_object_encryption_enc
-  ) {
-    return buildErrorResponse(
-      "invalid_client_metadata",
-      "Request Object encryption is not supported.",
-    );
-  }
-
-  config.token_endpoint_auth_method ||= "client_secret_basic";
+  config.token_endpoint_auth_method ??= "client_secret_basic";
   if (
     !TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED.includes(
       config.token_endpoint_auth_method,
@@ -428,39 +370,9 @@ export function validateRedirectUris(
   }
 
   if (application_type === "web") {
-    for (const uri of redirect_uris) {
-      if (!uri.startsWith("https://") && !process.env.TEST) {
-        return buildErrorResponse(
-          "invalid_redirect_uri",
-          "Redirect URIs must use HTTPS.",
-        );
-      }
-
-      const host = new URL(uri).hostname;
-      if (host == "localhost" && !process.env.TEST) {
-        return buildErrorResponse(
-          "invalid_redirect_uri",
-          "Redirect URIs must not use localhost.",
-        );
-      }
-    }
+    return validateWebRedirectUris(redirect_uris);
   } else if (application_type === "native") {
-    for (const uri of redirect_uris) {
-      if (uri.startsWith("http://")) {
-        const host = new URL(uri).hostname;
-        if (host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]") {
-          return buildErrorResponse(
-            "invalid_redirect_uri",
-            "Native clients must use custom URI schemes or loopback addresses on HTTP.",
-          );
-        }
-      } else if (uri.startsWith("https://")) {
-        return buildErrorResponse(
-          "invalid_redirect_uri",
-          "Native clients must not use HTTPS.",
-        );
-      }
-    }
+    return validateNativeRedirectUris(redirect_uris);
   } else {
     return buildErrorResponse(
       "invalid_client_metadata",
@@ -562,4 +474,96 @@ function buildErrorResponse(error: string, error_description: string) {
       },
     },
   );
+}
+
+function validateWebRedirectUris(redirectUris: string[]) {
+  for (const uri of redirectUris) {
+    if (!uri.startsWith("https://") && !process.env.TEST) {
+      return buildErrorResponse(
+        "invalid_redirect_uri",
+        "Redirect URIs must use HTTPS.",
+      );
+    }
+
+    const host = new URL(uri).hostname;
+    if (host == "localhost" && !process.env.TEST) {
+      return buildErrorResponse(
+        "invalid_redirect_uri",
+        "Redirect URIs must not use localhost.",
+      );
+    }
+  }
+}
+
+function validateNativeRedirectUris(redirectUris: string[]) {
+  for (const uri of redirectUris) {
+    if (uri.startsWith("http://")) {
+      const host = new URL(uri).hostname;
+      if (host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]") {
+        return buildErrorResponse(
+          "invalid_redirect_uri",
+          "Native clients must use custom URI schemes or loopback addresses on HTTP.",
+        );
+      }
+    } else if (uri.startsWith("https://")) {
+      return buildErrorResponse(
+        "invalid_redirect_uri",
+        "Native clients must not use HTTPS.",
+      );
+    }
+  }
+}
+
+async function validateSectorIdentifier(
+  config: z.infer<typeof registrationRequest>,
+) {
+  const sectorIdentifierUri = new URL(config.sector_identifier_uri!);
+  if (sectorIdentifierUri.protocol !== "https:") {
+    return buildErrorResponse(
+      "invalid_client_metadata",
+      "Sector Identifier URI must use HTTPS.",
+    );
+  }
+
+  let sectorIdentifierData;
+  try {
+    const sectorIdentifierResponse = await fetch(
+      config.sector_identifier_uri!,
+      {
+        headers: {
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(2000),
+      },
+    );
+
+    if (!sectorIdentifierResponse.ok) {
+      return buildErrorResponse(
+        "invalid_client_metadata",
+        "Failed to fetch sector identifier URI.",
+      );
+    }
+
+    sectorIdentifierData = await sectorIdentifierResponse.json();
+    if (!Array.isArray(sectorIdentifierData)) {
+      return buildErrorResponse(
+        "invalid_client_metadata",
+        "Sector Identifier URI must return an array.",
+      );
+    }
+  } catch {
+    return buildErrorResponse(
+      "invalid_client_metadata",
+      "Failed to fetch sector identifier URI.",
+    );
+  }
+
+  for (const uri of config.redirect_uris) {
+    if (!sectorIdentifierData.includes(uri)) {
+      return buildErrorResponse(
+        "invalid_client_metadata",
+        "All Redirect URIs must be included in sector identifier.",
+      );
+    }
+  }
 }

--- a/id/src/lib/oidc/token.ts
+++ b/id/src/lib/oidc/token.ts
@@ -106,21 +106,30 @@ async function authorizationCodeFlow(
     issuer += `/${tenant!.domain}`;
   }
 
-  const idToken = await createIdToken(
-    issuer,
-    client,
-    code.userId,
-    code.authTime,
-    {
-      ...requestedUserClaims(code.claims.id_token, user),
-      nonce: code.nonce,
-    },
-  );
+  if (code.scopes.includes("openid")) {
+    const idToken = await createIdToken(
+      issuer,
+      client,
+      code.userId,
+      code.authTime,
+      {
+        ...requestedUserClaims(code.claims.id_token, user),
+        nonce: code.nonce,
+      },
+    );
 
-  return Response.json({
-    access_token: uuidToHumanId(at.id, "oidc_at"),
-    token_type: "Bearer",
-    expires_in: 3600,
-    id_token: idToken,
-  });
+    return Response.json({
+      access_token: uuidToHumanId(at.id, "oidc_at"),
+      token_type: "Bearer",
+      expires_in: 3600,
+      id_token: idToken,
+    });
+  } else {
+    // Fallback to OAuth 2.0 behavior
+    return Response.json({
+      access_token: uuidToHumanId(at.id, "oidc_at"),
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  }
 }

--- a/id/src/lib/oidc/tokenAuthentication.ts
+++ b/id/src/lib/oidc/tokenAuthentication.ts
@@ -60,7 +60,7 @@ export async function authenticateClientSecretPost(
   }
 
   const params = await req.formParams;
-  const clientIdRaw = humanIdToUuid(params.client_id || "", "oidc");
+  const clientIdRaw = humanIdToUuid(params.client_id ?? "", "oidc");
   if (!clientIdRaw) {
     return false;
   }

--- a/id/src/lib/oidc/userinfo.spec.ts
+++ b/id/src/lib/oidc/userinfo.spec.ts
@@ -33,6 +33,7 @@ describe("Userinfo endpoint", () => {
       clientId: "00000000-0000-0000-0000-000000000001",
       userId: "00000000-0000-0000-0000-000000000001",
       expiresAt: new Date(Date.now() + 3600 * 1000),
+      scopes: ["openid"],
       ...attributes,
     });
 
@@ -89,6 +90,20 @@ describe("Userinfo endpoint", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  test("requires the access token to have the openid scope (otherwise it's an OAuth access token)", async () => {
+    const at = await makeAccessToken({
+      scopes: ["email"],
+    });
+
+    const response = await userinfoEndpoint(
+      makeRequest({
+        headers: { Authorization: "Bearer " + uuidToHumanId(at.id, "oidc_at") },
+      }),
+    );
+
+    expect(response.status).toBe(403);
   });
 
   test("it returns claims about the user", async () => {

--- a/id/src/lib/oidc/userinfo.ts
+++ b/id/src/lib/oidc/userinfo.ts
@@ -49,6 +49,10 @@ async function handle(req: HttpRequest) {
     return new Response(null, { status: 401 });
   }
 
+  if (!at.scopes.includes("openid")) {
+    return new Response(null, { status: 403 });
+  }
+
   const client = await OidcClients.find(at.clientId);
   if (!client) {
     return new Response(null, { status: 401 });

--- a/id/src/utils.ts
+++ b/id/src/utils.ts
@@ -95,3 +95,22 @@ export function humanIdToUuid(humanId: string, expectedPrefix: string) {
 
   return base62ToUuid(id);
 }
+
+export async function asyncFilter<T>(
+  arr: T[],
+  predicate: (value: T, index: number, array: any[]) => Promise<boolean>,
+): Promise<T[]> {
+  const results = await Promise.all(arr.map(predicate));
+  return arr.filter((_, i) => results[i]);
+}
+
+export async function asyncFind<T>(
+  arr: T[],
+  predicate: (value: T, index: number, array: any[]) => Promise<boolean>,
+): Promise<T | undefined> {
+  for (const [i, value] of arr.entries()) {
+    if (await predicate(value, i, arr)) {
+      return value;
+    }
+  }
+}

--- a/id/src/utils.ts
+++ b/id/src/utils.ts
@@ -56,8 +56,8 @@ export function hexToBase62(hex: string) {
 
 export function base62ToHex(base62: string) {
   let result = BigInt(0);
-  for (let i = 0; i < base62.length; i++) {
-    const char = base62[i];
+
+  for (let char of base62) {
     const value = BigInt(BASE62_ALPHABET.indexOf(char));
     result = result * BigInt(BASE62_ALPHABET.length) + value;
   }

--- a/id/tests/oidc/authorization.spec.ts
+++ b/id/tests/oidc/authorization.spec.ts
@@ -21,7 +21,7 @@ test.describe("OpenID Authorization endpoint", () => {
           `/oidc/authorize?${new URLSearchParams(basicRequest).toString()}`,
         );
 
-        await expect(page.getByText("Sign in")).toBeDefined();
+        expect(page.getByText("Sign in")).toBeDefined();
 
         await page.fill('input[name="username"]', "johndoe1");
         await page.fill('input[name="password"]', "super-s3cret");

--- a/id/tsconfig.json
+++ b/id/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The OIDC specification requires the `openid` scope to be passed in the Authorization request. However, when that's missing, we don't necessarily have to return an error.

This PR adjusts the authorization logic to allow noo id to work as an OAuth 2.0 Server as well. This is useful when third party apps require API access to customer resources without necessarily needing to authenticate the user.

When the `openid` scope is not passed, the request is "downgraded". An `id_token` will not be granted, and the access token resulting from the flow will not have access to the userinfo endpoint.